### PR TITLE
Adds get accounts endpoint on v2 of video indexer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,5 +26,6 @@ module.exports = {
     bingSpeech: require('./speech/bingSpeech'),
     bingEntitySearch: require('./search/bingEntitySearch'),
     contentModerator: require('./vision/contentModerator'),
-    videoIndexer: require('./vision/videoIndexer')
+    videoIndexer: require('./vision/videoIndexer'),
+    videoIndexerV2: require('./vision/videoIndexerV2')
 };

--- a/src/vision/videoIndexerV2.js
+++ b/src/vision/videoIndexerV2.js
@@ -1,0 +1,55 @@
+const commonService = require('../commonService');
+
+/**
+ * Video Indexer is a cloud service that enables you to extract the following insights from your videos using artificial intelligence technologies:
+ */
+class videoIndexerV2 extends commonService {
+    /**
+     * Constructor.
+     * 
+     * @param {Object} obj
+     * @param {string} obj.apiKey
+     */
+    constructor({ apiKey }) {
+        const endpoint = "api.videoindexer.ai/";
+        super({ apiKey, endpoint });
+        this.endpoints = [
+            endpoint
+        ];
+    }
+
+    getAccounts({
+            location,
+            generateAccessTokens,
+            allowEdit,
+    }) {
+        const operation = {
+            parameters: [
+                {
+                    name: 'location',
+                    type: 'queryStringParam'
+                },
+                {
+                    name: 'generateAccessTokens',
+                    type: 'queryStringParam'
+                },{
+                    name: 'allowEdit',
+                    type: 'queryStringParam'
+                },
+            ]
+        };
+
+        const requestParameters = {
+            location,
+            generateAccessTokens,
+            allowEdit
+        }
+
+        return this.makeRequest({
+            operation: operation,
+            parameters: requestParameters
+        })
+    }
+}
+
+module.exports = videoIndexerV2;

--- a/src/vision/videoIndexerV2.js
+++ b/src/vision/videoIndexerV2.js
@@ -11,7 +11,7 @@ class videoIndexerV2 extends commonService {
      * @param {string} obj.apiKey
      */
     constructor({ apiKey }) {
-        const endpoint = "api.videoindexer.ai/";
+        const endpoint = "api.videoindexer.ai";
         super({ apiKey, endpoint });
         this.endpoints = [
             endpoint
@@ -36,7 +36,9 @@ class videoIndexerV2 extends commonService {
                     name: 'allowEdit',
                     type: 'queryStringParam'
                 },
-            ]
+            ],
+            path: `auth/${location}/Accounts`,
+            method: 'GET'
         };
 
         const requestParameters = {

--- a/test/config.js
+++ b/test/config.js
@@ -74,5 +74,9 @@ module.exports = {
         apiKey: "insert-key-here",
         appID: "insert-appID-here",
         versionID: "0.1"
+    },
+    videoIndexerV2: {
+        endpoint: "api.videoindexer.ai",
+        apiKey: "insert-key-here"
     }
 }

--- a/test/config.js
+++ b/test/config.js
@@ -76,7 +76,6 @@ module.exports = {
         versionID: "0.1"
     },
     videoIndexerV2: {
-        endpoint: "api.videoindexer.ai",
         apiKey: "insert-key-here"
     }
 }

--- a/test/vision/videoIndexerV2Test.js
+++ b/test/vision/videoIndexerV2Test.js
@@ -1,0 +1,31 @@
+const cognitive = require('../../src/index.js');
+const config = require('../config.js');
+const should = require('should');
+
+describe.only('Video indexer', () => {
+
+    const client = new cognitive.videoIndexerV2({
+        apiKey: config.videoIndexerV2.apiKey
+    });
+
+    describe('Accounts Access Token', () => {
+        const requestParams = {
+            location: "trial",
+            allowEdit: false,
+            accountId: "your-account-id-here"
+        };
+        
+        it('should get an accounts access token', done => {
+            client.getAccountsAccessToken(requestParams)
+            .then(response => {
+                should(response).not.be.undefined();
+                should(response).be.a.String();
+                done();         
+            })
+            .catch(err => {
+                done(err);
+            })
+        })
+    })
+
+})

--- a/test/vision/videoIndexerV2Test.js
+++ b/test/vision/videoIndexerV2Test.js
@@ -2,24 +2,24 @@ const cognitive = require('../../src/index.js');
 const config = require('../config.js');
 const should = require('should');
 
-describe.only('Video indexer', () => {
+describe.only('Video Indexer V2', () => {
 
     const client = new cognitive.videoIndexerV2({
         apiKey: config.videoIndexerV2.apiKey
     });
 
-    describe('Accounts Access Token', () => {
+    describe('Get Accounts', () => {
         const requestParams = {
             location: "trial",
             allowEdit: false,
-            accountId: "your-account-id-here"
+            generateAccessTokens: true
         };
         
-        it('should get an accounts access token', done => {
-            client.getAccountsAccessToken(requestParams)
+        it('should return an array showing url and accounts access token', done => {
+            client.getAccounts(requestParams)
             .then(response => {
                 should(response).not.be.undefined();
-                should(response).be.a.String();
+                should(response).be.an.Array();
                 done();         
             })
             .catch(err => {


### PR DESCRIPTION
To ensure the `getAccounts` method of v2 of the video indexer api is working properly, I have written a unit test. As the video indexer has a large API, I wanted to do a small PR to check that my approach is correct before I plough ahead with the rest of the work.